### PR TITLE
Version bump to support GHC 9.12.2

### DIFF
--- a/puresat.cabal
+++ b/puresat.cabal
@@ -16,7 +16,7 @@ author:             Oleg Grenrus <oleg.grenrus@iki.fi>
 maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
 copyright:          (c) 2024 Oleg Grenrus
 build-type:         Simple
-tested-with:        GHC ==9.6.6 || ==9.8.2 || ==9.10.1
+tested-with:        GHC ==9.6.6 || ==9.8.2 || ==9.10.1 || ==9.12.2
 extra-doc-files:    CHANGELOG.md
 
 -- cabal-fmt: glob-files dimacs/**/*.cnf
@@ -318,7 +318,7 @@ library internal
     PureSAT.Vec
 
   build-depends:
-    , base        >=4.18.2.1 && <4.21
+    , base        >=4.18.2.1 && <4.22
     , containers  >=0.6.7    && <0.8
     , primitive   ^>=0.9.0.0
 


### PR DESCRIPTION
Bump version of base dependency to be able to use puresat with GHC 9.12.2